### PR TITLE
Add in-memory cache

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Osama Qarem
+Copyright (c) 2021 Osama Qarem
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install the pod, then rebuild the app.
 Start by importing the module
 
 ```js
-import ImageColors from "react-native-image-colors"
+import ImageColors from 'react-native-image-colors'
 ```
 
 🎨 Fetch colors
@@ -86,24 +86,26 @@ Can be:
 - Local file:
 
   ```js
-  const catImg = require("./images/cat.jpg")
+  const catImg = require('./images/cat.jpg')
   ```
 
 - Base64:
 
   ```js
-  const catImgBase64 = "data:image/jpeg;base64,/9j/4Ri..."
+  const catImgBase64 = 'data:image/jpeg;base64,/9j/4Ri...'
   ```
 
   > The mime type prefix for base64 is required (e.g. data:image/png;base64).
 
 ### config
 
-| Property                      | Description                                                                                                                                                 | Type                                                   | Required | Default     |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | -------- | ----------- |
-| `fallback`                    | If a color property couldn't be retrieved, it will default to this hex color string (**note**: do not use shorthand hex. e.g. `#fff`).                      | `string`                                               | No       | `"#000000"` |
-| `pixelSpacing` (Android only) | How many pixels to skip when iterating over image pixels. Higher means better performance (**note**: value cannot be lower than 1).                         | `number`                                               | No       | `5`         |
-| `quality` (iOS only)          | Highest implies no downscaling and very good colors, but it is very slow. See [UIImageColors](https://github.com/jathu/UIImageColors#uiimagecolors-objects) | `'lowest'` <br> `'low'` <br> `'high'` <br> `'highest'` | No       | `"low"`     |
+| Property                      | Description                                                                                                                                                                                    | Type                                                   | Required | Default     |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | -------- | ----------- |
+| `fallback`                    | If a color property couldn't be retrieved, it will default to this hex color string (**note**: do not use shorthand hex. e.g. `#fff`).                                                         | `string`                                               | No       | `"#000000"` |
+| `cache`                       | Enables in-memory caching of the result.                                                                                                                                                       | `boolean`                                              | No       | `false`     |
+| `key`                         | Unique key to use for the cache entry. The image URI is used as the unique key by default. You should explicitly pass a key if you enable caching and you're using a base64 string as the URI. | `string`                                               | No       | `undefined` |
+| `pixelSpacing` (Android only) | How many pixels to skip when iterating over image pixels. Higher means better performance (**note**: value cannot be lower than 1).                                                            | `number`                                               | No       | `5`         |
+| `quality` (iOS only)          | Highest implies no downscaling and very good colors, but it is very slow. See [UIImageColors](https://github.com/jathu/UIImageColors#uiimagecolors-objects)                                    | `'lowest'` <br> `'low'` <br> `'high'` <br> `'highest'` | No       | `"low"`     |
 
 ### Result (android)
 
@@ -136,13 +138,15 @@ On iOS, you get the following color properties object, plus the respective platf
 ### Example
 
 ```js
-const coolImage = require("./cool.jpg")
+const coolImage = require('./cool.jpg')
 
 const colors = await ImageColors.getColors(coolImage, {
-  fallback: "#228B22",
+  fallback: '#228B22',
+  cache: true,
+  key: 'unique_key',
 })
 
-if (colors.platform === "android") {
+if (colors.platform === 'android') {
   // Access android properties
   // e.g.
   const averageColor = colors.average

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -24,6 +24,7 @@ export default function App() {
         fallback: '#000000',
         quality: 'low',
         pixelSpacing: 5,
+        cache: true,
       })
 
       if (result.platform === 'android') {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "@release-it/conventional-changelog": "^2.0.0",
+    "@testing-library/jest-native": "^4.0.1",
+    "@testing-library/react-native": "^7.2.0",
     "@types/jest": "^26.0.0",
     "@types/react": "^16.9.19",
     "@types/react-native": "0.62.13",

--- a/src/__tests__/image-colors.spec.tsx
+++ b/src/__tests__/image-colors.spec.tsx
@@ -1,0 +1,144 @@
+import { NativeModules } from 'react-native'
+import ImageColors from '..'
+import type { IOSImageColors } from '../types'
+
+const { ImageColors: NativeImageColors } = NativeModules
+
+jest.mock('react-native', () => ({
+  NativeModules: {
+    ImageColors: {
+      getColors: jest.fn(),
+    },
+  },
+}))
+
+const mockResult: IOSImageColors = {
+  background: '#000000',
+  primary: '#120120',
+  secondary: '#123123',
+  detail: '#321321',
+  quality: 'low',
+  platform: 'ios' as const,
+}
+
+const uri = 'uri'
+
+describe('react-native-image-colors', () => {
+  describe('getColors', () => {
+    beforeAll(() => {
+      NativeImageColors.getColors = jest.fn().mockReturnValue(mockResult)
+    })
+
+    describe('when cache is enabled', () => {
+      afterEach(() => {
+        jest.restoreAllMocks()
+        ImageColors.cache.clear()
+      })
+
+      it('stores new result into cache', async () => {
+        jest.spyOn(ImageColors.cache, 'setItem')
+        jest.spyOn(ImageColors.cache, 'getItem')
+
+        const result = await ImageColors.getColors(uri, { cache: true })
+
+        expect(ImageColors.cache.getItem).toHaveBeenCalledWith(uri)
+        expect(ImageColors.cache.setItem).toHaveBeenCalled()
+
+        const cacheResult = ImageColors.cache.getItem(uri)
+        expect(result).toEqual(cacheResult)
+      })
+
+      it('returns old result from cache', async () => {
+        const nothing = ImageColors.cache.getItem(uri)
+        expect(nothing).toBeUndefined()
+
+        ImageColors.cache.setItem(uri, mockResult)
+
+        jest.spyOn(ImageColors.cache, 'setItem')
+        jest.spyOn(ImageColors.cache, 'getItem')
+
+        const result = await ImageColors.getColors(uri, { cache: true })
+
+        expect(mockResult).toEqual(result)
+        expect(ImageColors.cache.getItem).toHaveBeenCalledWith(uri)
+        expect(ImageColors.cache.setItem).not.toHaveBeenCalled()
+      })
+
+      describe('cache key', () => {
+        beforeEach(() => {
+          jest.spyOn(ImageColors.cache, 'setItem')
+          jest.spyOn(ImageColors.cache, 'getItem')
+        })
+
+        afterEach(() => {
+          jest.restoreAllMocks()
+          ImageColors.cache.clear()
+        })
+
+        it('uses uri when key is not defined', async () => {
+          await ImageColors.getColors(uri, { cache: true })
+
+          expect(ImageColors.cache.getItem).toHaveBeenCalledWith(uri)
+          expect(ImageColors.cache.setItem).toHaveBeenCalledWith(
+            uri,
+            mockResult
+          )
+        })
+
+        it('uses key if it is defined', async () => {
+          const key = 'key'
+          await ImageColors.getColors(uri, { cache: true, key })
+
+          expect(ImageColors.cache.getItem).toHaveBeenCalledWith(key)
+          expect(ImageColors.cache.setItem).toHaveBeenCalledWith(
+            key,
+            mockResult
+          )
+        })
+
+        it('throws an error if the key is too large', async () => {
+          await expect(
+            ImageColors.getColors(uri.repeat(400), {
+              cache: true,
+            })
+          ).rejects.toThrow()
+        })
+      })
+    })
+
+    describe('when cache is disabled', () => {
+      afterEach(() => {
+        jest.restoreAllMocks()
+      })
+
+      it('never caches any result', async () => {
+        jest.spyOn(ImageColors.cache, 'setItem')
+        jest.spyOn(ImageColors.cache, 'getItem')
+
+        NativeImageColors.getColors = jest
+          .fn()
+          .mockReturnValueOnce({ ...mockResult })
+
+        const firstCallResult = await ImageColors.getColors(uri, {
+          cache: false,
+        })
+
+        expect(ImageColors.cache.getItem).not.toHaveBeenCalled()
+        expect(ImageColors.cache.setItem).not.toHaveBeenCalled()
+
+        NativeImageColors.getColors = jest
+          .fn()
+          .mockReturnValueOnce({ ...mockResult })
+
+        const secondCallResult = await ImageColors.getColors(uri, {
+          cache: false,
+        })
+
+        expect(ImageColors.cache.getItem).not.toHaveBeenCalled()
+        expect(ImageColors.cache.setItem).not.toHaveBeenCalled()
+
+        expect(firstCallResult).not.toBe(secondCallResult)
+      })
+    })
+  })
+})

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,27 @@
+import type { ImageColorsResult } from './types'
+
+let storage: Record<string, ImageColorsResult | undefined> = {}
+
+const getItem = (key: string) => {
+  return storage[key]
+}
+
+const setItem = (key: string, value: ImageColorsResult) => {
+  storage[key] = value
+}
+
+const removeItem = (key: string) => {
+  return delete storage[key]
+}
+
+const clear = () => {
+  storage = {}
+  return true
+}
+
+export const cache = {
+  getItem,
+  setItem,
+  removeItem,
+  clear,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,49 @@
 import { NativeModules, Image } from 'react-native'
+import { cache } from './cache'
+import type { ImageRequireSource } from 'react-native'
 import type { RNImageColorsModule } from './types'
+
+const MAX_KEY_LEN = 500
 
 const { ImageColors: RNImageColors } = NativeModules
 
-const ImageColors: RNImageColorsModule = {
-  getColors: (source, config) => {
-    if (typeof source === 'string') {
-      return RNImageColors.getColors(source, config)
-    } else {
-      const resolvedSource = Image.resolveAssetSource(source).uri
-      return RNImageColors.getColors(resolvedSource, config)
+const resolveImageSource = (source: string | ImageRequireSource): string => {
+  if (typeof source === 'string') {
+    return source
+  } else {
+    return Image.resolveAssetSource(source).uri
+  }
+}
+
+const getColors: RNImageColorsModule['getColors'] = async (source, config) => {
+  const resolvedSrc = resolveImageSource(source)
+
+  if (config?.cache) {
+    const cachedResult = config.key
+      ? cache.getItem(config.key)
+      : cache.getItem(resolvedSrc)
+
+    if (cachedResult) return cachedResult
+  }
+
+  const result = await RNImageColors.getColors(resolvedSrc, config)
+
+  if (config?.cache) {
+    if (!config.key && resolvedSrc.length > MAX_KEY_LEN) {
+      throw new Error(
+        `You enabled caching, but you didn't pass a key. We fallback to using the image URI as the key. However the URI is longer than ${MAX_KEY_LEN}. Please pass a short unique key.`
+      )
     }
-  },
+
+    cache.setItem(config.key ?? resolvedSrc, result)
+  }
+
+  return result
+}
+
+const ImageColors: RNImageColorsModule = {
+  getColors,
+  cache,
 }
 
 export default ImageColors

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { cache } from 'src/cache'
+
 export interface AndroidImageColors {
   dominant?: string
   average?: string
@@ -23,13 +25,18 @@ export interface Config {
   fallback?: string
   pixelSpacing?: number
   quality?: 'lowest' | 'low' | 'high' | 'highest'
+  cache?: boolean
+  key?: string
 }
+
+export type ImageColorsResult = AndroidImageColors | IOSImageColors
 
 declare function GetColors<C extends Config>(
   url: string,
   config?: C
-): Promise<AndroidImageColors | IOSImageColors>
+): Promise<ImageColorsResult>
 
 export interface RNImageColorsModule {
   getColors: typeof GetColors
+  cache: typeof cache
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,6 +1778,25 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testing-library/jest-native@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-4.0.1.tgz#000902622cb44f0d723a9f0e9eb8699f3ea511ae"
+  integrity sha512-dqeVpMSb8nZ1QxvzHxiKb4MqepNfFt8MeUwq9r/BTIOIrUFjDRDSpReZXVv9tcQypz2BcjbNK7BAEvyLSF33hQ==
+  dependencies:
+    chalk "^2.4.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    pretty-format "^24.0.0"
+    ramda "^0.26.1"
+    redent "^2.0.0"
+
+"@testing-library/react-native@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.2.0.tgz#e5ec5b0974e4e5f525f8057563417d1e9f820d96"
+  integrity sha512-rDKzJjAAeGgyoJT0gFQiMsIL09chdWcwZyYx6WZHMgm2c5NDqY52hUuyTkzhqddMYWmSRklFphSg7B2HX+246Q==
+  dependencies:
+    pretty-format "^26.0.1"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
@@ -3652,6 +3671,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
@@ -5053,6 +5077,11 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
@@ -5623,6 +5652,16 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
+jest-diff@^24.0.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
@@ -5757,6 +5796,16 @@ jest-leak-detector@^26.6.2:
   dependencies:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
@@ -7647,7 +7696,7 @@ prettier@^2.0.2, prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -7667,7 +7716,7 @@ pretty-format@^25.1.0, pretty-format@^25.2.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^26.0.0, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.0.1, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -7794,6 +7843,11 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -7991,6 +8045,14 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -8953,6 +9015,11 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-indent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Closes #10 

## Summary

- Simple in-memory cache.
- Tiny implementation in JS (no calls over bridge).
- Should improve network and performance overhead especially when using large remote images on different screens.
- Disabled by default. Enabled by passing `cache: true` to the config.
- Uses the URI as the cache key by default. A `key` property can be passed in the config instead.
- In case of a long URI (e.g. base64): an error will be thrown for keys over a specific length (we dont want to hold an entire image in memory by accident).
- Cache object exposed in types, but won't be documented on purpose.

## Todo

- [X] Code
- [X] Tests
- [x] Docs