### PR TITLE
update minSdkVersion for capability with react-native 0.64

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion getExtOrDefault('minSdkVersion')
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,5 @@
 ImageColors_kotlinVersion=1.3.50
 ImageColors_compileSdkVersion=29
+ImageColors_minSdkVersion=16
 ImageColors_buildToolsVersion=29.0.2
 ImageColors_targetSdkVersion=29


### PR DESCRIPTION
its need for fix this problem

```
> Task :react-native-splash-screen:processDebugAndroidTestManifest FAILED
[androidx.vectordrawable:vectordrawable-animated:1.0.0] /Users/Bibaland/.gradle/caches/transforms-2/files-2.1/c3b5f5ee05598f90df6de44797b88246/vectordrawable-animated-1.0.0/AndroidManifest.xml Warning:
        Package name 'androidx.vectordrawable' used in: androidx.vectordrawable:vectordrawable-animated:1.0.0, androidx.vectordrawable:vectordrawable:1.0.1.
/Users/Bibaland/IdeaProjects/unoto-mobole/node_modules/react-native-splash-screen/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger88074441399679852.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.2] /Users/Bibaland/.gradle/caches/transforms-2/files-2.1/c57a8a5544dd554c09a21065fbefeeed/jetified-react-native-0.64.2/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```