### PR TITLE
Bump kotlin version to 1.6.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ImageColors_kotlinVersion=1.3.50
+ImageColors_kotlinVersion=1.6.0
 ImageColors_compileSdkVersion=29
 ImageColors_minSdkVersion=16
 ImageColors_buildToolsVersion=29.0.2


### PR DESCRIPTION
Bump Kotlin version to 1.6.0 for fix build android version for react native >0.70.x