### PR TITLE
docs: update minimum required iOS version to 13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx expo run:android
 #### Requirements
 
 - React Native v0.70.0+
-- iOS 13+
+- iOS 13.4+
 - [Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) must be configured
 
 > Users on < RN0.69 and older can use v1.x.x


### PR DESCRIPTION
When trying to install into an expo project, I was getting

    ⚠️  Something went wrong running `pod install` in the `ios` directory.
    Command `pod install` failed.
    └─ Cause: CocoaPods could not find compatible versions for pod "ImageColors":
      In Podfile:
        ImageColors (from `../node_modules/react-native-image-colors/ios`)

    Specs satisfying the `ImageColors (from `../node_modules/react-native-image-colors/ios`)` dependency were found, but they required a higher minimum deployment target.

    pod install --repo-update --ansi exited with non-zero code: 1
    
It looks to be caused by `node_modules/react-native-image-colors/ios/ImageColors.podspec:13` where there's a minimum requirement of iOS `13.4`.  Upgrading the `ios` > `deploymentTarget` build property to 13.4 fixed the issue for me.  Might save a few minutes for someone else in the future to have the exact minimum version target mentioned.

If it _should_ work with iOS 13 then feel free to ignore this and I can create an issue instead.