### PR TITLE
Add support for base64 SVG images

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,4 +90,5 @@ dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "androidx.palette:palette:1.0.0"
+  implementation "com.caverock:androidsvg:1.4"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,5 +90,5 @@ dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "androidx.palette:palette:1.0.0"
-  implementation "com.caverock:androidsvg:1.4"
+  implementation "com.caverock:androidsvg-aar:1.4"
 }

--- a/android/src/main/java/com/reactnativeimagecolors/ImageColorsModule.kt
+++ b/android/src/main/java/com/reactnativeimagecolors/ImageColorsModule.kt
@@ -2,12 +2,14 @@ package com.reactnativeimagecolors
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas
 import android.graphics.Color
 import android.net.Uri
 import android.util.Base64
 import android.util.Log
 import android.webkit.URLUtil
 import androidx.palette.graphics.Palette
+import com.caverock.androidsvg.SVG as AndroidSVG
 
 import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.kotlin.Promise
@@ -123,7 +125,18 @@ class ImageColorsModule : Module() {
             val base64Uri = uri.split(",")[1]
             val decodedBytes = Base64.decode(base64Uri, Base64.DEFAULT)
 
-            image = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
+            if (uri.startsWith("data:image/svg")) {
+              val svgString = String(decodedBytes, Charsets.UTF_8)
+              val svg = AndroidSVG.getFromString(svgString)
+              val width = if (svg.documentWidth > 0) svg.documentWidth.toInt() else 200
+              val height = if (svg.documentHeight > 0) svg.documentHeight.toInt() else 200
+              val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+              val canvas = Canvas(bitmap)
+              svg.renderToCanvas(canvas)
+              image = bitmap
+            } else {
+              image = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
+            }
           }
 
           // check if content URI

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -16,6 +16,10 @@ const yunaUrl = 'https://i.imgur.com/68jyjZT.jpg'
 // const catUrl = 'https://i.imgur.com/O3XSdU7.jpg'
 // const catImg = require('../assets/cat.jpg')
 
+// 120x120 SVG: dark background (#1B1B3A), red/orange/navy circles, teal bar
+// const base64Image =
+//   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgdmlld0JveD0iMCAwIDEyMCAxMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHJlY3Qgd2lkdGg9IjEyMCIgaGVpZ2h0PSIxMjAiIGZpbGw9IiMxQjFCM0EiLz4KICA8Y2lyY2xlIGN4PSIzNSIgY3k9IjQwIiByPSIyNSIgZmlsbD0iI0U5NDU2MCIvPgogIDxjaXJjbGUgY3g9Ijg1IiBjeT0iNDAiIHI9IjI1IiBmaWxsPSIjRjVBNjIzIi8+CiAgPGNpcmNsZSBjeD0iNjAiIGN5PSI4MCIgcj0iMjUiIGZpbGw9IiMwRjM0NjAiLz4KICA8cmVjdCB4PSIxMCIgeT0iMTAwIiB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEyIiByeD0iNiIgZmlsbD0iIzE2Qzc5QSIvPgo8L3N2Zz4='
+
 const initialState = {
   colorOne: { value: '', name: '' },
   colorTwo: { value: '', name: '' },

--- a/ios/ImageColors.podspec
+++ b/ios/ImageColors.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.dependency 'SwiftDraw', '~> 0.27'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ImageColorsModule.swift
+++ b/ios/ImageColorsModule.swift
@@ -122,7 +122,7 @@ public class ImageColorsModule: Module {
                 return
             }
 
-            if uri.hasPrefix("data:image") {
+            if uri.hasPrefix("data:image/svg") {
                 guard let commaIndex = uri.firstIndex(of: ",") else {
                     promise.reject(NSError(domain: ImageColorsModule.ERRORS.INVALID_URL, code: -1))
                     return
@@ -133,11 +133,8 @@ public class ImageColorsModule: Module {
                     return
                 }
 
-                let isSVG = uri.hasPrefix("data:image/svg")
-                let uiImage: UIImage? = isSVG
-                    ? SVG(data: data)?.rasterize(scale: 1)
-                    : UIImage(data: data)
-
+                let uiImage: UIImage? = SVG(data: data)?.rasterize(scale: 1)
+                
                 guard let uiImage else {
                     promise.reject(NSError(domain: ImageColorsModule.ERRORS.PARSE_ERR, code: -3))
                     return

--- a/ios/ImageColorsModule.swift
+++ b/ios/ImageColorsModule.swift
@@ -1,5 +1,6 @@
 import ExpoModulesCore
 import UIKit
+import SwiftDraw
 
 public class ImageColorsModule: Module {
 
@@ -127,8 +128,17 @@ public class ImageColorsModule: Module {
                     return
                 }
                 let base64String = String(uri[uri.index(after: commaIndex)...])
-                guard let data = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters),
-                      let uiImage = UIImage(data: data) else {
+                guard let data = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters) else {
+                    promise.reject(NSError(domain: ImageColorsModule.ERRORS.PARSE_ERR, code: -3))
+                    return
+                }
+
+                let isSVG = uri.hasPrefix("data:image/svg")
+                let uiImage: UIImage? = isSVG
+                    ? SVG(data: data)?.rasterize(scale: 1)
+                    : UIImage(data: data)
+
+                guard let uiImage else {
                     promise.reject(NSError(domain: ImageColorsModule.ERRORS.PARSE_ERR, code: -3))
                     return
                 }

--- a/ios/ImageColorsModule.swift
+++ b/ios/ImageColorsModule.swift
@@ -77,6 +77,40 @@ public class ImageColorsModule: Module {
         var quality: String = QUALITY.LOW
     }
 
+    private func resolveColors(image: UIImage, quality qualityOption: String, fallback fallbackColor: String, promise: Promise) {
+        let quality = getQuality(qualityOption: qualityOption)
+
+        image.getColors(quality: quality) { colors in
+            var resultDict: Dictionary<String, String> = ["platform": "ios"]
+
+            if let background = colors?.background {
+                resultDict["background"] = self.toHexString(color: background)
+            } else {
+                resultDict["background"] = fallbackColor
+            }
+
+            if let primary = colors?.primary {
+                resultDict["primary"] = self.toHexString(color: primary)
+            } else {
+                resultDict["primary"] = fallbackColor
+            }
+
+            if let secondary = colors?.secondary {
+                resultDict["secondary"] = self.toHexString(color: secondary)
+            } else {
+                resultDict["secondary"] = fallbackColor
+            }
+
+            if let detail = colors?.detail {
+                resultDict["detail"] = self.toHexString(color: detail)
+            } else {
+                resultDict["detail"] = fallbackColor
+            }
+
+            promise.resolve(resultDict)
+        }
+    }
+
     public func definition() -> ModuleDefinition {
         Name("ImageColors")
 
@@ -84,6 +118,21 @@ public class ImageColorsModule: Module {
             guard let fallbackColor = parseFallbackColor(hexColor: config.fallback) else {
                 let error = NSError.init(domain: ImageColorsModule.ERRORS.INVALID_FALLBACK_COLOR, code: -1)
                 promise.reject(error)
+                return
+            }
+
+            if uri.hasPrefix("data:image") {
+                guard let commaIndex = uri.firstIndex(of: ",") else {
+                    promise.reject(NSError(domain: ImageColorsModule.ERRORS.INVALID_URL, code: -1))
+                    return
+                }
+                let base64String = String(uri[uri.index(after: commaIndex)...])
+                guard let data = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters),
+                      let uiImage = UIImage(data: data) else {
+                    promise.reject(NSError(domain: ImageColorsModule.ERRORS.PARSE_ERR, code: -3))
+                    return
+                }
+                self.resolveColors(image: uiImage, quality: config.quality, fallback: fallbackColor, promise: promise)
                 return
             }
 
@@ -111,40 +160,7 @@ public class ImageColorsModule: Module {
                     return
                 }
 
-                let qualityProp = config.quality
-                let quality = getQuality(qualityOption: qualityProp)
-
-                uiImage.getColors(quality: quality) { colors in
-                    var resultDict: Dictionary<String, String> = ["platform": "ios"]
-
-                    if let background = colors?.background {
-                        resultDict["background"] = self.toHexString(color: background)
-                    } else {
-                        resultDict["background"] = fallbackColor
-                    }
-
-
-                    if let primary = colors?.primary {
-                        resultDict["primary"] = self.toHexString(color: primary)
-                    } else {
-                        resultDict["primary"] = fallbackColor
-                    }
-
-
-                    if let secondary = colors?.secondary {
-                        resultDict["secondary"] = self.toHexString(color: secondary)
-                    } else {
-                        resultDict["secondary"] = fallbackColor
-                    }
-
-                    if let detail = colors?.detail {
-                        resultDict["detail"] = self.toHexString(color: detail)
-                    } else {
-                        resultDict["detail"] = fallbackColor
-                    }
-
-                    promise.resolve(resultDict)
-                }
+                self.resolveColors(image: uiImage, quality: config.quality, fallback: fallbackColor, promise: promise)
             }.resume()
         }
     }


### PR DESCRIPTION
Closes #107 

# Changes

## iOS
- Added base64 images support
- Added support for base64 svgs

## Android
- Added support for base64 svgs

# Notes
I wanted to handle svgs as it was required for my use case. We could just return errors for base64 svgs but I thought it would be cool to support everything (and it was useful for me).

When implementing svg support I had 2 approaches:

1. Installing androidsvg on Android and SwiftDraw on iOS. 
- Pros: Cleaner code.
- Cons: Adds dependencies.
2. Using web views to render svgs and take a snapshot.
- Pros: No extra dependencies.
- Cons: Not so clean and worst performance.